### PR TITLE
Propagate attributes and tags

### DIFF
--- a/jobs/yamt/spec
+++ b/jobs/yamt/spec
@@ -21,7 +21,7 @@ properties:
     default: []
   yamt.attributes:
     description: "Attributes to be attached to each reported event"
-    default: []
+    default: {}
   yamt.ignore_interfaces:
     description: "Interfaces to ignore."
     default: "lo"

--- a/jobs/yamt/templates/yamt_ctl.erb
+++ b/jobs/yamt/templates/yamt_ctl.erb
@@ -25,10 +25,10 @@ case $1 in
       --attribute bosh-job=<%= name %> \
       --attribute bosh-deployment=<%= spec.deployment %> \
 <% p("yamt.attributes").each do |k, v| %> \
-      --attribute <%= esc("#{k}=#{v}") %> \
+      --attribute <%= "#{k}=#{v}" %> \
 <% end %> \
 <% p("yamt.tags").each do |tag| %> \
-      --tag <%= esc(tag) %> \
+      --tag <%= tag %> \
 <% end %> \
       >>  $LOG_DIR/yamt.stdout.log \
       2>> $LOG_DIR/yamt.stderr.log

--- a/jobs/yamt/templates/yamt_ctl.erb
+++ b/jobs/yamt/templates/yamt_ctl.erb
@@ -22,6 +22,14 @@ case $1 in
       --ignore-interfaces "<%= p("yamt.ignore_interfaces") %>" \
       --disk \
       --ignore-devices "<%= p("yamt.ignore_devices") %>" \
+      --attribute bosh-job=<%= name %> \
+      --attribute bosh-deployment=<%= spec.deployment %> \
+<% p("yamt.attributes").each do |k, v| %> \
+      --attribute <%= esc("#{k}=#{v}") %> \
+<% end %> \
+<% p("yamt.tags").each do |tag| %> \
+      --tag <%= esc(tag) %> \
+<% end %> \
       >>  $LOG_DIR/yamt.stdout.log \
       2>> $LOG_DIR/yamt.stderr.log
     ;;

--- a/templates/warden.yml
+++ b/templates/warden.yml
@@ -49,3 +49,7 @@ update:
 properties:
   yamt:
     host: 10.244.20.18
+    tags: ["rate", "fooproduct"]
+    attributes:
+      landscape: prod
+      productive: true


### PR DESCRIPTION
Propagate `yamt.attributes` and `yamt.tags` from release job properties to yamt executable.
